### PR TITLE
Use __cdecl for airwave host (wine 5.8+)

### DIFF
--- a/src/host/main.cpp
+++ b/src/host/main.cpp
@@ -8,7 +8,7 @@
 using namespace Airwave;
 
 
-int main(int argc, const char* argv[])
+int __cdecl main(int argc, const char* argv[])
 {
 	if(argc != 5) {
 		fprintf(stderr, "Airwave host endpoint, version " VERSION_STRING);


### PR DESCRIPTION
Fixes #111

Tested with wine 5.9-1